### PR TITLE
Fix footnotes

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,25 @@ You can _just_ add the Markdown plugins by using the `htex/markdown` export.
 | [markdown-it-mathjax3](https://npmjs.com/package/markdown-it-mathjax3) | `math` | Math rendering (using MathJax 3). |
 | [markdown-it-deflist](https://npmjs.com/package/markdown-it-deflist) | `definitionLists` | Definition lists. |
 | [markdown-it-table-captions](https://npmjs.com/package/markdown-it-table-captions) | `tableCaptions` | Table captions. |
-| [markdown-it-footnote](https://npmjs.com/package/markdown-it-footnote) | `footnote` | Footnotes. |
+| [markdown-it-footnote](https://npmjs.com/package/markdown-it-footnote) | `footnote` | Footnotes. Comes with an optional `footnotes.css` for styling footnotes with a separator line and proper spacing. |
 | [markdown-it-bracketed-spans](https://npmjs.com/package/markdown-it-bracketed-spans) | `spans` | Concise bracketed spans. |
 | [markdown-it-sup](https://npmjs.com/package/markdown-it-sup) | `sup` | Superscripts using `^`. |
 | [markdown-it-sub](https://npmjs.com/package/markdown-it-sub) | `sub` | Subscripts using `~`. |
+
+## Styling
+
+### Footnotes
+
+To style footnotes, you can import the included CSS file:
+
+```css
+@import "htex/markdown-it/footnotes.css";
+```
+
+This provides a clean layout for footnotes with:
+- Superscript footnote references
+- A separator line before the footnotes section
+- Proper spacing and alignment
+- Customizable separator length and thickness via CSS custom properties:
+  - `--footnotes-separator-length` (default: `15ch`)
+  - `--footnotes-separator-thickness` (default: `1px`)

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "main": "src/index.js",
   "exports": {
     "./eleventy": "./src/index.js",
-    "./markdown-it": "./src/markdown-it.js"
+    "./markdown-it": "./src/markdown-it.js",
+    "./markdown-it/footnotes.css": "./src/md/footnotes.css"
   },
   "scripts": {
     "release": "release-it",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,6 @@
     "reading-time": "^1.5"
   },
   "devDependencies": {
-    "release-it": "^17.6.0"
+    "release-it": "^19.0.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "main": "src/index.js",
   "exports": {
     "./eleventy": "./src/index.js",
-    "./markdown-it": "./src/markdown-it.js",
+    "./markdown-it": "./src/markdown.js",
     "./markdown-it/footnotes.css": "./src/md/footnotes.css"
   },
   "scripts": {

--- a/src/md/footnotes.css
+++ b/src/md/footnotes.css
@@ -1,0 +1,40 @@
+.footnote-ref,
+.footnote::before {
+	font-size: 70%;
+	vertical-align: super;
+}
+
+.footnote {
+	position: relative;
+	padding-inline-start: .5em;
+	margin-inline-start: -1em;
+	page-break-before: avoid;
+	counter-increment: footnote;
+	font-size: 70%;
+	line-height: 1.2;
+
+	&:nth-child(1 of .footnote) {
+		margin-top: 1em;
+		padding-block-start: 1lh;
+		background: linear-gradient(currentcolor 0% 100%) 0 0 / var(--footnotes-separator-length, 15ch) var(--footnotes-separator-thickness, 1px) no-repeat;
+
+		.footnote-marker {
+			inset-block-start: 1lh;
+		}
+	}
+
+	.footnote-marker {
+		position: absolute;
+		inset-inline-end: 100%;
+		inset-block-start: 0;
+	}
+}
+
+.footnote-backref {
+	font-family: monospace;
+
+	&::after {
+		/* Prevent display as emoji */
+		content: "\FE0E";
+	}
+}

--- a/src/md/footnotes.css
+++ b/src/md/footnotes.css
@@ -1,10 +1,10 @@
 .footnote-ref,
-.footnote::before {
+.footnote-item::before {
 	font-size: 70%;
 	vertical-align: super;
 }
 
-.footnote {
+.footnote-item {
 	position: relative;
 	padding-inline-start: .5em;
 	margin-inline-start: -1em;
@@ -13,7 +13,7 @@
 	font-size: 70%;
 	line-height: 1.2;
 
-	&:nth-child(1 of .footnote) {
+	&:nth-child(1 of &) {
 		margin-top: 1em;
 		padding-block-start: 1lh;
 		background: linear-gradient(currentcolor 0% 100%) 0 0 / var(--footnotes-separator-length, 15ch) var(--footnotes-separator-thickness, 1px) no-repeat;


### PR DESCRIPTION
### Summary

- Bump up the `release-it` package version to fix known vulnerabilities
- Move `footnotes.css` from the (not used) `markdown-it-footnote` plugin fork
- Fix class names: `.footnote` → `.footnote-item` (as it’s called in `markdown-it-footnote`)
- Update exports in `package.json`: add a new rule for `footnotes.css` and fix the `markdown-it` rule

After merging this PR and releasing a new version of hTex, we can update the repo with the thesis. Unfortunately, we can’t use `vertical-align: super` for the footnote markers, since the `::marker` pseudo-item [doesn’t support this property](https://developer.mozilla.org/en-US/docs/Web/CSS/::marker#allowable_properties).

<img width="782" alt="image" src="https://github.com/user-attachments/assets/c46185c2-774a-42dc-b198-6de24408ac0b" />

As for me, it’s OK for now. However, we should probably consider using our own (pseudo-)items as footnote markers to achieve the desired appearance in our other projects.

There's an option to overcome those limitations with a custom counter style; however, it involves some tweaks to the fonts used so that markers look correct. See this pen: https://codepen.io/dmitrysharabin/pen/raaxqmq?editors=1100
Should we enable those rules by default? 🤔

<img width="772" alt="image" src="https://github.com/user-attachments/assets/f94af99b-b183-4b7f-8a28-e3ebf2085b2d" />
